### PR TITLE
Fix command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ live-server                  # Mở UI tại http://127.0.0.1:8080
 ## 🤝 Contributing
 1. **Fork** this repo  
 2. **Branch**: `git checkout -b feature/YourFeature`  
-3. **Commit**: `git.commit -m "Implement YourFeature"`  
+3. **Commit**: `git commit -m "Implement YourFeature"`
 4. **Push**: `git.push origin feature/YourFeature`  
 5. **PR**: Open a pull request—let’s ship fast.  
 


### PR DESCRIPTION
## Summary
- fix the git commit command in Contributing section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fb0cece54832480352fd5dbd123de