### PR TITLE
Fix role handling in register

### DIFF
--- a/comic-backend/controllers/authController.js
+++ b/comic-backend/controllers/authController.js
@@ -7,14 +7,18 @@ const User = require('../models/User');
 // @access  Public
 exports.register = async (req, res, next) => {
     try {
-        const { username, email, password, role } = req.body;
+        const { username, email, password, role: requestedRole } = req.body;
 
-        // Tạo người dùng
+        // Chỉ chấp nhận các vai trò nằm trong danh sách cho phép
+        const allowedRoles = ['user']; // Mở rộng khi cần tạo admin qua route riêng
+        const role = allowedRoles.includes(requestedRole) ? requestedRole : 'user';
+
+        // Tạo người dùng với vai trò đã được kiểm soát
         const user = await User.create({
             username,
             email,
             password,
-            role // Tùy chọn: chỉ cho phép các vai trò cụ thể hoặc mặc định là 'user'
+            role
         });
 
         sendTokenResponse(user, 201, res);

--- a/comic-backend/package.json
+++ b/comic-backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "dev": "nodemon server.js"
   },
   "keywords": [],

--- a/comic-backend/test/authController.test.js
+++ b/comic-backend/test/authController.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+let createdData;
+const mockUser = {
+  create: async data => {
+    createdData = data;
+    return { ...data, _doc: data, getSignedJwtToken: () => 'token' };
+  }
+};
+
+// Replace the real User model with the mock
+const userPath = path.join(__dirname, '..', 'models', 'User.js');
+const resolved = require.resolve(userPath);
+const originalUserModule = require.cache[resolved];
+require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports: mockUser };
+
+const { register } = require('../controllers/authController');
+
+test('register defaults to user role when role is arbitrary', async () => {
+  const req = { body: { username: 'bob', email: 'bob@example.com', password: 'pass', role: 'admin' } };
+  const res = { status(code){ this.statusCode = code; return this; }, json(data){ this.data = data; return this; } };
+  await register(req, res);
+  assert.strictEqual(createdData.role, 'user');
+  assert.strictEqual(res.statusCode, 201);
+  assert.ok(res.data.success);
+});
+
+// Restore original module
+require.cache[resolved] = originalUserModule;


### PR DESCRIPTION
## Summary
- reject arbitrary role values in register controller
- add test for register role handling
- run tests with Node's built-in runner

## Testing
- `npm test` in `comic-backend`

------
https://chatgpt.com/codex/tasks/task_e_683fb0e11dc0832491c078f59b062260