### PR TITLE
Fix relative assets in GH Pages build

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ cd ../comic-frontend
 npm install -g live-server   # optional
 live-server                  # Mở UI tại http://127.0.0.1:8080
 ```
+### Deploying to GitHub Pages
+```bash
+cd comic-frontend
+VITE_BASE_PATH=/Comic-Project npm run build
+npm run deploy
+```
+
 
 ---
 

--- a/comic-frontend/vite.config.js
+++ b/comic-frontend/vite.config.js
@@ -2,7 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+const basePath = process.env.VITE_BASE_PATH || './'
+
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: basePath,
 })


### PR DESCRIPTION
## Summary
- read `VITE_BASE_PATH` env var or default to `./` in the vite config
- document GitHub Pages build and deploy steps

## Testing
- `npm run build` inside `comic-frontend`
- `npm run lint` *(fails: process env and undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5588b048324b2d64a186cdb6447