### PR TITLE
Fix asset paths for subdirectory hosting

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trang Chủ - Web Đọc Truyện</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" crossorigin href="./assets/index-C-Uo3YUY.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="icon" href="static/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" crossorigin href="/assets/index-C-Uo3YUY.css">


### PR DESCRIPTION
## Summary
- fix `docs/index.html` CSS path so that it uses `./assets/...`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*
- `npm test` in repo root *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fb8ff87088324a2d403ff80f344ec