### PR TITLE
Convert frontend scripts to modules

### DIFF
--- a/comic-frontend/category.html
+++ b/comic-frontend/category.html
@@ -68,16 +68,16 @@
 
     <footer id="footer-placeholder"></footer>
 
-    <script src="js/main.js"></script>
-    <script src="js/api.js"></script>
-    <script src="js/category.js"></script>
-    <script>
+    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/api.js"></script>
+    <script type="module" src="js/category.js"></script>
+    <script type="module">
+        import { loadComponent } from './js/main.js';
+        import { initCategoryPage } from './js/category.js';
         window.addEventListener('DOMContentLoaded', async () => {
             await loadComponent('components/navbar.html', 'navbar-placeholder');
             await loadComponent('components/footer.html', 'footer-placeholder');
-            if (typeof initCategoryPage === 'function') {
-                initCategoryPage();
-            }
+            initCategoryPage();
         });
     </script>
 </body>

--- a/comic-frontend/chapter-reader.html
+++ b/comic-frontend/chapter-reader.html
@@ -56,17 +56,16 @@
     </div>
 
 
-    <script src="js/main.js"></script> 
-    <script src="js/api.js"></script>
-    <script src="js/chapter-reader.js"></script>
-    <script>
+    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/api.js"></script>
+    <script type="module" src="js/chapter-reader.js"></script>
+    <script type="module">
+        import { initChapterReaderPage } from './js/chapter-reader.js';
         window.addEventListener('DOMContentLoaded', () => {
             // The dark mode button 'toggle-dark-mode-reader' now has class 'dark-mode-toggle-button'
             // and will be handled by the global applyInitialDarkMode in main.js.
             // No specific setup needed here for its click listener or icon update.
-            if (typeof initChapterReaderPage === 'function') {
-                initChapterReaderPage();
-            }
+            initChapterReaderPage();
         });
     </script>
 </body>

--- a/comic-frontend/comic-detail.html
+++ b/comic-frontend/comic-detail.html
@@ -59,16 +59,16 @@
 
     <footer id="footer-placeholder"></footer>
 
-    <script src="js/main.js"></script>
-    <script src="js/api.js"></script>
-    <script src="js/comic-detail.js"></script>
-    <script>
+    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/api.js"></script>
+    <script type="module" src="js/comic-detail.js"></script>
+    <script type="module">
+        import { loadComponent } from './js/main.js';
+        import { initComicDetailPage } from './js/comic-detail.js';
         window.addEventListener('DOMContentLoaded', async () => {
             await loadComponent('components/navbar.html', 'navbar-placeholder');
             await loadComponent('components/footer.html', 'footer-placeholder');
-            if (typeof initComicDetailPage === 'function') {
-                initComicDetailPage();
-            }
+            initComicDetailPage();
         });
     </script>
 </body>

--- a/comic-frontend/js/category.js
+++ b/comic-frontend/js/category.js
@@ -1,4 +1,7 @@
 // comic-frontend/js/category.js
+import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
+
 async function initCategoryPage() {
     console.log("Đang khởi tạo Trang Thể Loại với dữ liệu từ Backend...");
     const categoryNameElement = document.getElementById('category-name')?.querySelector('span');
@@ -170,4 +173,5 @@ async function initCategoryPage() {
         fetchAndDisplayComics(newPage);
     });
 }
+export { initCategoryPage };
 console.log("category.js đã được tải và sẵn sàng tương tác với backend.");

--- a/comic-frontend/js/chapter-reader.js
+++ b/comic-frontend/js/chapter-reader.js
@@ -1,4 +1,6 @@
 // comic-frontend/js/chapter-reader.js
+import { apiRequest } from './api.js';
+
 async function initChapterReaderPage() {
     console.log("Đang khởi tạo Trang Đọc Truyện với dữ liệu từ Backend...");
     const chapterImagesContainer = document.getElementById('chapter-images');
@@ -154,5 +156,6 @@ async function initChapterReaderPage() {
         chapterSelect.disabled = true;
     }
 }
+export { initChapterReaderPage };
 console.log("chapter-reader.js đã được tải và sẵn sàng tương tác với backend.");
 

--- a/comic-frontend/js/comic-detail.js
+++ b/comic-frontend/js/comic-detail.js
@@ -1,4 +1,7 @@
 // comic-frontend/js/comic-detail.js
+import { apiRequest } from './api.js';
+import { populateChapterItem } from './main.js';
+
 async function initComicDetailPage() {
     console.log("Đang khởi tạo Trang Chi Tiết Truyện với dữ liệu từ Backend...");
     const comicDetailContent = document.getElementById('comic-detail-content');
@@ -109,5 +112,6 @@ async function initComicDetailPage() {
         comicDetailContent.innerHTML = `<p class="text-red-500 text-center p-10">Lỗi tải thông tin truyện: ${error.message}</p>`;
     }
 }
+export { initComicDetailPage };
 console.log("comic-detail.js đã được tải và sẵn sàng tương tác với backend.");
 

--- a/comic-frontend/js/home.js
+++ b/comic-frontend/js/home.js
@@ -1,5 +1,6 @@
 // comic-frontend/js/home.js
 import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
 
 async function initHomePage() {
     console.log("Đang khởi tạo Trang Chủ với dữ liệu từ Backend...");

--- a/comic-frontend/js/main.js
+++ b/comic-frontend/js/main.js
@@ -121,6 +121,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Các khởi tạo toàn cục khác có thể đặt ở đây
 });
 
-export { loadComponent, toggleDarkMode };
+export { loadComponent, toggleDarkMode, populateComicCard, populateChapterItem };
 
 console.log("main.js đã được tải và các hàm đã được định nghĩa.");

--- a/comic-frontend/js/search.js
+++ b/comic-frontend/js/search.js
@@ -1,4 +1,6 @@
 // comic-frontend/js/search.js
+import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
 async function initSearchPage() {
     console.log("Đang khởi tạo Trang Tìm Kiếm với dữ liệu từ Backend...");
     const searchForm = document.getElementById('advanced-search-form');


### PR DESCRIPTION
## Summary
- expose `populateComicCard` and `populateChapterItem` in `main.js`
- consume exported helpers in page scripts
- export page init functions for module usage
- load page code via `<script type="module">` and import initializers

## Testing
- `npm test` *(fails: missing script)*
- `cd comic-backend && npm test` *(fails: Cannot find module 'supertest')*
- `cd comic-frontend && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fb900cd148324b0b49d15454aa98b