### PR TITLE
Update gitignore to track docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules/
 npm-debug.log
 *.log
 /dist/
-/docs/


### PR DESCRIPTION
## Summary
- track the built documentation

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_683fbfdfcb3483249829e4893c0fa69c