### PR TITLE
Remove stray absolute CSS link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,6 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="icon" href="static/favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" crossorigin href="/assets/index-C-Uo3YUY.css">
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-sans">
 


### PR DESCRIPTION
## Summary
- fix docs/index.html so stylesheet is referenced with a relative path only

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fbfdfedcc83248fac6b0c0ee817d5