### PR TITLE
Copy frontend scripts to docs and update index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,9 +63,7 @@
 
     <footer id="footer-placeholder"></footer>
 
-    <script src="js/main.js"></script>
-    <script src="js/api.js"></script>
-    <script src="js/home.js"></script>
+    <script type="module" src="./js/init.js"></script>
     <script>
         // Load components
         window.addEventListener('DOMContentLoaded', async () => {

--- a/docs/js/api.js
+++ b/docs/js/api.js
@@ -1,0 +1,71 @@
+// comic-frontend/js/api.js
+const API_BASE_URL = 'https://tuongtruyen.io.vn/api'; // Đảm bảo cổng này (5000) khớp với backend PORT của bạn
+
+/**
+ * Hàm chung để thực hiện các yêu cầu API đến backend.
+ * @param {string} endpoint - Điểm cuối API (ví dụ: '/stories', '/stories/storyId/chapters').
+ * @param {string} [method='GET'] - Phương thức HTTP (GET, POST, PUT, DELETE).
+ * @param {object} [body=null] - Dữ liệu gửi đi cho POST/PUT.
+ * @param {object} [customHeaders={}] - Các header tùy chỉnh.
+ * @returns {Promise<any>} - Dữ liệu JSON từ API.
+ * @throws {Error} - Ném lỗi nếu yêu cầu API thất bại.
+ */
+async function apiRequest(endpoint, method = 'GET', body = null, customHeaders = {}) {
+    const url = `${API_BASE_URL}${endpoint}`;
+    const token = localStorage.getItem('authToken'); // Lấy token từ localStorage (nếu có)
+
+    const headers = {
+        // 'Content-Type': 'application/json', // Sẽ được đặt tự động bởi fetch cho FormData
+        ...customHeaders,
+    };
+
+    if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const config = {
+        method: method,
+        headers: headers,
+    };
+
+    // Chỉ đặt Content-Type là application/json nếu body không phải là FormData
+    if (body && !(body instanceof FormData)) {
+        config.headers['Content-Type'] = 'application/json';
+        config.body = JSON.stringify(body);
+    } else if (body instanceof FormData) {
+        config.body = body; // fetch sẽ tự động đặt Content-Type cho FormData
+    }
+
+
+    try {
+        const response = await fetch(url, config);
+
+        if (!response.ok) {
+            let errorData;
+            try {
+                errorData = await response.json();
+            } catch (e) {
+                // Nếu không parse được JSON (ví dụ lỗi server trả về HTML)
+                errorData = { message: `Yêu cầu thất bại với trạng thái ${response.status} ${response.statusText}` };
+            }
+            // Ưu tiên hiển thị lỗi cụ thể từ backend nếu có
+            throw new Error(errorData.error || errorData.message || `Lỗi HTTP! Trạng thái: ${response.status}`);
+        }
+
+        // Xử lý trường hợp response không có nội dung (ví dụ: 204 No Content sau khi DELETE)
+        if (response.status === 204 || response.headers.get("content-length") === "0") {
+            return { success: true }; // Hoặc null, tùy theo cách bạn muốn xử lý
+        }
+
+        return await response.json(); // Phân tích cú pháp JSON từ response
+    } catch (error) {
+        console.error(`Yêu cầu API đến ${method} ${url} thất bại:`, error.message);
+        // Bạn có thể thêm xử lý lỗi toàn cục ở đây, ví dụ: hiển thị thông báo cho người dùng
+        // Hoặc nếu lỗi là 401 (Unauthorized), có thể điều hướng về trang đăng nhập.
+        throw error; // Ném lại lỗi để nơi gọi có thể xử lý cụ thể
+    }
+}
+
+export { apiRequest };
+
+console.log("api.js (để tương tác với backend) đã được tải.");

--- a/docs/js/category.js
+++ b/docs/js/category.js
@@ -1,0 +1,177 @@
+// comic-frontend/js/category.js
+import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
+
+async function initCategoryPage() {
+    console.log("Đang khởi tạo Trang Thể Loại với dữ liệu từ Backend...");
+    const categoryNameElement = document.getElementById('category-name')?.querySelector('span');
+    const categoryComicsList = document.getElementById('category-comics-list');
+    const filterStatusSelect = document.getElementById('filter-status');
+    const sortBySelect = document.getElementById('sort-by');
+    const applyFiltersBtn = document.getElementById('apply-filters-btn');
+    const paginationContainer = document.getElementById('pagination');
+
+
+    if (!categoryNameElement || !categoryComicsList || !filterStatusSelect || !sortBySelect || !applyFiltersBtn || !paginationContainer) {
+        console.error("Một hoặc nhiều phần tử cho trang thể loại không được tìm thấy.");
+        if(categoryComicsList) categoryComicsList.innerHTML = '<p class="text-red-500 col-span-full text-center py-10">Lỗi giao diện trang thể loại.</p>';
+        return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const genreQuery = params.get('genre'); // ví dụ: 'action', 'romance'
+
+    if (!genreQuery) {
+        categoryNameElement.textContent = 'Không xác định';
+        categoryComicsList.innerHTML = '<p class="text-red-500 col-span-full text-center py-10">Vui lòng chọn một thể loại từ menu.</p>';
+        return;
+    }
+
+    const displayGenre = genreQuery.charAt(0).toUpperCase() + genreQuery.slice(1);
+    categoryNameElement.textContent = displayGenre;
+    document.title = `Thể Loại: ${displayGenre} - Web Đọc Truyện`;
+
+    let currentPage = parseInt(params.get('page')) || 1;
+
+    async function fetchAndDisplayComics(page = 1) {
+        currentPage = page;
+        categoryComicsList.innerHTML = '<p class="col-span-full text-center text-gray-500 dark:text-gray-400 py-10">Đang tải danh sách truyện...</p>';
+        paginationContainer.innerHTML = ''; // Xóa phân trang cũ
+
+        try {
+            const statusFilter = filterStatusSelect.value;
+            const sortOption = sortBySelect.value;
+
+            let apiEndpoint = `/stories?genre=${encodeURIComponent(genreQuery)}&page=${currentPage}&limit=18`; // 18 truyện mỗi trang
+
+            if (statusFilter !== 'all') {
+                apiEndpoint += `&status=${statusFilter}`;
+            }
+            if (sortOption) {
+                // Backend xử lý sort: ví dụ 'name_asc' -> sort=title, 'views_desc' -> sort=-views
+                let sortQuery;
+                switch(sortOption) {
+                    case 'name_asc': sortQuery = 'title'; break;
+                    case 'name_desc': sortQuery = '-title'; break;
+                    case 'views_desc': sortQuery = '-views'; break;
+                    case 'updated_desc': sortQuery = '-updatedAt'; break;
+                    default: sortQuery = '-updatedAt';
+                }
+                apiEndpoint += `&sort=${sortQuery}`;
+            }
+
+            const response = await apiRequest(apiEndpoint);
+
+            if (response.success && response.data) {
+                const comics = response.data;
+                const comicCardTemplate = await fetch('components/comic-card.html').then(res => res.text());
+                
+                categoryComicsList.innerHTML = ''; // Xóa loading
+                if (comics.length === 0) {
+                    categoryComicsList.innerHTML = `<p class="col-span-full text-center text-gray-500 dark:text-gray-400 py-10">Không có truyện nào thuộc thể loại "${displayGenre}" với bộ lọc hiện tại.</p>`;
+                } else {
+                    comics.forEach(comic => {
+                        const cardHtml = populateComicCard(comicCardTemplate, comic);
+                        categoryComicsList.insertAdjacentHTML('beforeend', cardHtml);
+                    });
+                }
+                renderPagination(response.pagination, response.total, response.count);
+            } else {
+                throw new Error(response.error || 'Không thể tải danh sách truyện.');
+            }
+
+        } catch (error) {
+            console.error(`Lỗi tải truyện cho thể loại ${genreQuery}:`, error);
+            categoryComicsList.innerHTML = `<p class="text-red-500 col-span-full text-center py-10">Lỗi tải danh sách truyện: ${error.message}</p>`;
+        }
+    }
+    
+    function renderPagination(paginationData, totalItems, itemsOnPage) {
+        if (!paginationData && totalItems <= itemsOnPage) { // Không cần phân trang nếu chỉ có 1 trang
+            paginationContainer.innerHTML = '';
+            return;
+        }
+
+        let paginationHTML = '<ul class="inline-flex items-center -space-x-px">';
+        const limit = 18; // Số item mỗi trang, cần đồng bộ với API
+        const totalPages = Math.ceil(totalItems / limit);
+
+        // Nút Previous
+        if (paginationData && paginationData.prev) {
+            paginationHTML += `<li><a href="#" data-page="${paginationData.prev.page}" class="pagination-link py-2 px-3 ml-0 leading-tight text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">Trước</a></li>`;
+        } else {
+            paginationHTML += `<li><span class="py-2 px-3 ml-0 leading-tight text-gray-400 bg-white rounded-l-lg border border-gray-300 cursor-not-allowed dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500">Trước</span></li>`;
+        }
+
+        // Số trang (hiển thị một vài trang xung quanh trang hiện tại)
+        const maxPagesToShow = 5;
+        let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+        let endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+        if (totalPages > maxPagesToShow && endPage - startPage + 1 < maxPagesToShow) {
+             startPage = Math.max(1, endPage - maxPagesToShow + 1);
+        }
+
+
+        if (startPage > 1) {
+            paginationHTML += `<li><a href="#" data-page="1" class="pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">1</a></li>`;
+            if (startPage > 2) {
+                paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">...</span></li>`;
+            }
+        }
+
+        for (let i = startPage; i <= endPage; i++) {
+            if (i === currentPage) {
+                paginationHTML += `<li><span aria-current="page" class="z-10 py-2 px-3 leading-tight text-blue-600 bg-blue-50 border border-blue-300 dark:border-gray-700 dark:bg-gray-700 dark:text-white">${i}</span></li>`;
+            } else {
+                paginationHTML += `<li><a href="#" data-page="${i}" class="pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">${i}</a></li>`;
+            }
+        }
+        
+        if (endPage < totalPages) {
+            if (endPage < totalPages - 1) {
+                paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">...</span></li>`;
+            }
+            paginationHTML += `<li><a href="#" data-page="${totalPages}" class="pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">${totalPages}</a></li>`;
+        }
+
+
+        // Nút Next
+        if (paginationData && paginationData.next) {
+            paginationHTML += `<li><a href="#" data-page="${paginationData.next.page}" class="pagination-link py-2 px-3 leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">Sau</a></li>`;
+        } else {
+            paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-400 bg-white rounded-r-lg border border-gray-300 cursor-not-allowed dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500">Sau</span></li>`;
+        }
+
+        paginationHTML += '</ul>';
+        paginationContainer.innerHTML = paginationHTML;
+
+        // Gắn event listener cho các nút phân trang
+        document.querySelectorAll('.pagination-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const page = parseInt(e.target.closest('a').dataset.page);
+                const currentUrlParams = new URLSearchParams(window.location.search);
+                currentUrlParams.set('page', page);
+                history.pushState(null, '', `${window.location.pathname}?${currentUrlParams.toString()}`);
+                fetchAndDisplayComics(page);
+            });
+        });
+    }
+
+
+    applyFiltersBtn.addEventListener('click', () => fetchAndDisplayComics(1)); // Khi lọc, về trang 1
+    filterStatusSelect.addEventListener('change', () => fetchAndDisplayComics(1));
+    sortBySelect.addEventListener('change', () => fetchAndDisplayComics(1));
+    
+    // Tải lần đầu
+    fetchAndDisplayComics(currentPage);
+
+    // Xử lý khi người dùng nhấn nút back/forward của trình duyệt
+    window.addEventListener('popstate', () => {
+        const newParams = new URLSearchParams(window.location.search);
+        const newPage = parseInt(newParams.get('page')) || 1;
+        fetchAndDisplayComics(newPage);
+    });
+}
+export { initCategoryPage };
+console.log("category.js đã được tải và sẵn sàng tương tác với backend.");

--- a/docs/js/chapter-reader.js
+++ b/docs/js/chapter-reader.js
@@ -1,0 +1,161 @@
+// comic-frontend/js/chapter-reader.js
+import { apiRequest } from './api.js';
+
+async function initChapterReaderPage() {
+    console.log("Đang khởi tạo Trang Đọc Truyện với dữ liệu từ Backend...");
+    const chapterImagesContainer = document.getElementById('chapter-images');
+    const comicTitleElement = document.getElementById('comic-title-reader');
+    const chapterTitleElement = document.getElementById('chapter-title-reader');
+    const chapterSelect = document.getElementById('chapter-select');
+    const prevChapterBtn = document.getElementById('prev-chapter-btn');
+    const nextChapterBtn = document.getElementById('next-chapter-btn');
+
+    if (!chapterImagesContainer || !comicTitleElement || !chapterTitleElement || !chapterSelect || !prevChapterBtn || !nextChapterBtn) {
+        console.error("Một hoặc nhiều phần tử cho trang đọc truyện không được tìm thấy.");
+        if(chapterImagesContainer) chapterImagesContainer.innerHTML = '<p class="text-red-500 p-5 text-center">Lỗi giao diện đọc truyện. Vui lòng thử lại.</p>';
+        return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const comicId = params.get('comicId');
+    let currentChapterId = params.get('chapterId');
+
+    if (!comicId || !currentChapterId) {
+        chapterImagesContainer.innerHTML = '<p class="text-red-500 text-center p-5">Thiếu thông tin truyện hoặc chương để hiển thị.</p>';
+        return;
+    }
+
+    chapterImagesContainer.innerHTML = '<p class="text-gray-500 dark:text-gray-400 text-center p-10">Đang tải dữ liệu chương...</p>';
+
+    try {
+        // Lấy thông tin truyện (để hiển thị tên truyện)
+        const comicResponse = await apiRequest(`/stories/${comicId}`);
+        if (!comicResponse.success || !comicResponse.data) {
+            throw new Error(comicResponse.error || 'Không tìm thấy thông tin truyện.');
+        }
+        const comic = comicResponse.data;
+        comicTitleElement.textContent = comic.title;
+        document.title = `Đọc ${comic.title} - Web Đọc Truyện`;
+
+        // Lấy tất cả các chương của truyện này để tạo dropdown và điều hướng
+        const chaptersResponse = await apiRequest(`/stories/${comicId}/chapters`);
+        if (!chaptersResponse.success || !chaptersResponse.data || chaptersResponse.data.length === 0) {
+            throw new Error(chaptersResponse.error || 'Không tìm thấy danh sách chương cho truyện này.');
+        }
+        const allChaptersForComic = chaptersResponse.data; // API đã sort chapterNumber tăng dần
+
+        // Điền vào chapter select dropdown (sắp xếp theo chapterNumber để dễ chọn)
+        chapterSelect.innerHTML = '';
+        allChaptersForComic.forEach(chap => {
+            const option = document.createElement('option');
+            option.value = chap._id; // Sử dụng _id của chapter
+            option.textContent = chap.title || `Chương ${chap.chapterNumber}`;
+            if (chap._id === currentChapterId) {
+                option.selected = true;
+            }
+            chapterSelect.appendChild(option);
+        });
+
+        // Hàm để tải và hiển thị nội dung một chương cụ thể
+        const loadChapterContent = async (chapterIdToLoad) => {
+            currentChapterId = chapterIdToLoad; // Cập nhật chapter ID hiện tại
+            // Cập nhật URL mà không tải lại trang (tùy chọn)
+            const newUrl = `chapter-reader.html?comicId=${comicId}&chapterId=${chapterIdToLoad}`;
+            history.pushState({ path: newUrl }, '', newUrl);
+
+            chapterImagesContainer.innerHTML = '<p class="text-gray-500 dark:text-gray-400 text-center p-10">Đang tải ảnh truyện...</p>';
+
+            // Lấy chi tiết chương hiện tại (bao gồm mảng 'pages')
+            const currentChapterDetailsResponse = await apiRequest(`/stories/${comicId}/chapters/${chapterIdToLoad}`);
+            if (!currentChapterDetailsResponse.success || !currentChapterDetailsResponse.data) {
+                chapterImagesContainer.innerHTML = `<p class="text-red-500 text-center p-5">Lỗi tải nội dung chương: ${currentChapterDetailsResponse.error || 'Không tìm thấy chương'}</p>`;
+                return;
+            }
+            const currentChapter = currentChapterDetailsResponse.data;
+            chapterTitleElement.textContent = currentChapter.title || `Chương ${currentChapter.chapterNumber}`;
+
+            if (currentChapter.pages && currentChapter.pages.length > 0) {
+                let imagesHTML = '';
+                currentChapter.pages.forEach((imageUrl, index) => {
+                    // Sử dụng ảnh placeholder nếu URL không hợp lệ hoặc để test
+                    const actualImageUrl = imageUrl && imageUrl.startsWith('http') ? imageUrl : `https://placehold.co/800x1200/2c3e50/ecf0f1?text=${encodeURIComponent(currentChapter.title || 'Trang')}+${index + 1}&font=montserrat`;
+                    imagesHTML += `<img src="${actualImageUrl}" alt="Trang ${index + 1} - ${currentChapter.title}" class="mb-0.5" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/800x1200/e74c3c/ffffff?text=Lỗi+tải+ảnh&font=montserrat';">`;
+                });
+                chapterImagesContainer.innerHTML = imagesHTML;
+            } else {
+                chapterImagesContainer.innerHTML = `<p class="text-gray-500 dark:text-gray-400 text-center p-10">Chương này chưa có nội dung hình ảnh.</p>`;
+            }
+            window.scrollTo({ top: 0, behavior: 'auto' }); // Cuộn lên đầu trang khi tải chương mới
+
+            // Cập nhật nút điều hướng Previous/Next
+            const currentIndexInAllChapters = allChaptersForComic.findIndex(c => c._id === chapterIdToLoad);
+
+            // Nút "Chap Sau" (chương có chapterNumber lớn hơn, hoặc index lớn hơn trong mảng đã sort tăng dần)
+            if (currentIndexInAllChapters < allChaptersForComic.length - 1) {
+                nextChapterBtn.href = `chapter-reader.html?comicId=${comicId}&chapterId=${allChaptersForComic[currentIndexInAllChapters + 1]._id}`;
+                nextChapterBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+            } else {
+                nextChapterBtn.href = '#';
+                nextChapterBtn.classList.add('opacity-50', 'cursor-not-allowed');
+            }
+
+            // Nút "Chap Trước" (chương có chapterNumber nhỏ hơn, hoặc index nhỏ hơn)
+            if (currentIndexInAllChapters > 0) {
+                prevChapterBtn.href = `chapter-reader.html?comicId=${comicId}&chapterId=${allChaptersForComic[currentIndexInAllChapters - 1]._id}`;
+                prevChapterBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+            } else {
+                prevChapterBtn.href = '#';
+                prevChapterBtn.classList.add('opacity-50', 'cursor-not-allowed');
+            }
+            // Cập nhật giá trị được chọn trong dropdown
+            chapterSelect.value = chapterIdToLoad;
+        };
+
+        // Tải nội dung chương ban đầu
+        await loadChapterContent(currentChapterId);
+
+        // Listener cho dropdown chọn chương
+        chapterSelect.addEventListener('change', (event) => {
+            loadChapterContent(event.target.value);
+        });
+
+        // Listener cho nút điều hướng (để JS xử lý thay vì tải lại trang hoàn toàn)
+        const handleNavButtonClick = (buttonElement, event) => {
+            if (buttonElement.classList.contains('cursor-not-allowed')) {
+                event.preventDefault();
+            } else {
+                const targetChapterId = new URL(buttonElement.href).searchParams.get('chapterId');
+                if (targetChapterId) {
+                    event.preventDefault(); // Ngăn điều hướng mặc định
+                    loadChapterContent(targetChapterId);
+                }
+            }
+        };
+        prevChapterBtn.addEventListener('click', (e) => handleNavButtonClick(prevChapterBtn, e));
+        nextChapterBtn.addEventListener('click', (e) => handleNavButtonClick(nextChapterBtn, e));
+
+        // Điều hướng bằng phím mũi tên
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowLeft') { // Chap trước
+                if (!prevChapterBtn.classList.contains('cursor-not-allowed')) {
+                    prevChapterBtn.click();
+                }
+            } else if (e.key === 'ArrowRight') { // Chap sau
+                 if (!nextChapterBtn.classList.contains('cursor-not-allowed')) {
+                    nextChapterBtn.click();
+                }
+            }
+        });
+
+    } catch (error) {
+        console.error("Lỗi khởi tạo trang đọc truyện:", error);
+        chapterImagesContainer.innerHTML = `<p class="text-red-500 text-center p-10">Đã xảy ra lỗi khi tải dữ liệu chương: ${error.message}</p>`;
+        // Vô hiệu hóa các nút điều khiển nếu có lỗi nghiêm trọng
+        prevChapterBtn.classList.add('opacity-50', 'cursor-not-allowed');
+        nextChapterBtn.classList.add('opacity-50', 'cursor-not-allowed');
+        chapterSelect.disabled = true;
+    }
+}
+export { initChapterReaderPage };
+console.log("chapter-reader.js đã được tải và sẵn sàng tương tác với backend.");
+

--- a/docs/js/comic-detail.js
+++ b/docs/js/comic-detail.js
@@ -1,0 +1,117 @@
+// comic-frontend/js/comic-detail.js
+import { apiRequest } from './api.js';
+import { populateChapterItem } from './main.js';
+
+async function initComicDetailPage() {
+    console.log("Đang khởi tạo Trang Chi Tiết Truyện với dữ liệu từ Backend...");
+    const comicDetailContent = document.getElementById('comic-detail-content');
+    if (!comicDetailContent) {
+        console.error("Không tìm thấy phần tử nội dung chi tiết truyện.");
+        return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const comicId = params.get('id');
+
+    if (!comicId) {
+        comicDetailContent.innerHTML = '<p class="text-red-500 text-center p-6">Không tìm thấy ID truyện trong URL.</p>';
+        return;
+    }
+
+    comicDetailContent.innerHTML = '<p class="text-gray-500 dark:text-gray-400 text-center p-10">Đang tải thông tin truyện...</p>';
+
+    try {
+        // Lấy thông tin truyện
+        const comicResponse = await apiRequest(`/stories/${comicId}`);
+        if (!comicResponse.success || !comicResponse.data) {
+            throw new Error(comicResponse.error || 'Không thể tải thông tin truyện.');
+        }
+        const comic = comicResponse.data;
+        document.title = `${comic.title || 'Chi tiết truyện'} - Web Đọc Truyện`;
+
+        // Lấy danh sách chương
+        const chaptersResponse = await apiRequest(`/stories/${comicId}/chapters`);
+        let chapters = [];
+        if (chaptersResponse.success && chaptersResponse.data) {
+            chapters = chaptersResponse.data; // API đã sắp xếp chương mới nhất ở đầu (chapterNumber giảm dần)
+                                            // hoặc chapterNumber tăng dần tùy vào backend
+                                            // Hiện tại backend sort chapterNumber tăng dần
+        } else {
+            console.warn("Không thể tải danh sách chương:", chaptersResponse.error);
+        }
+        
+        comicDetailContent.innerHTML = `
+            <div class="flex flex-col md:flex-row gap-6 md:gap-8">
+                <div class="md:w-1/3 lg:w-1/4 flex-shrink-0">
+                    <img src="${comic.coverImage || 'assets/images/cover-placeholder.jpg'}" alt="Bìa truyện ${comic.title}" class="w-full h-auto object-cover rounded-lg shadow-xl aspect-[2/3]" onerror="this.onerror=null;this.src='https://placehold.co/400x600/eeeeee/999999?text=Ảnh+Bìa&font=roboto';">
+                </div>
+                <div class="md:w-2/3 lg:w-3/4 space-y-3">
+                    <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold text-blue-600 dark:text-blue-400 break-words">${comic.title || 'Chưa có tiêu đề'}</h1>
+                    <p class="text-gray-700 dark:text-gray-300"><strong class="font-semibold">Tác giả:</strong> ${comic.author || 'Đang cập nhật'}</p>
+                    <p class="text-gray-700 dark:text-gray-300"><strong class="font-semibold">Thể loại:</strong> ${comic.genres && comic.genres.length > 0 ? comic.genres.join(', ') : 'Chưa rõ'}</p>
+                    <p class="text-gray-700 dark:text-gray-300"><strong class="font-semibold">Trạng thái:</strong> ${comic.status === 'ongoing' ? 'Đang cập nhật' : (comic.status === 'completed' ? 'Hoàn thành' : 'Tạm ngưng')}</p>
+                    <p class="text-gray-700 dark:text-gray-300"><strong class="font-semibold">Lượt xem:</strong> ${comic.views ? comic.views.toLocaleString() : '0'}</p>
+                    <div class="mt-2 flex items-center">
+                        <strong class="font-semibold mr-2">Đánh giá:</strong>
+                        <span class="text-yellow-400">
+                            ${[...Array(5)].map((_, i) => `<i class="fa-${i < Math.round(comic.rating || 0) ? 'solid' : 'regular'} fa-star"></i>`).join('')}
+                        </span>
+                        <span class="ml-2 text-sm text-gray-600 dark:text-gray-400">(${comic.rating || 0}/5)</span>
+                    </div>
+                    <div class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                        <strong class="font-semibold block mb-1 text-gray-800 dark:text-gray-200">Mô tả:</strong>
+                        <p class="text-gray-600 dark:text-gray-400 leading-relaxed text-sm">${comic.description || 'Chưa có mô tả.'}</p>
+                    </div>
+                    <div class="mt-4 flex flex-wrap gap-3">
+                        <a href="${chapters.length > 0 ? `chapter-reader.html?comicId=${comic._id}&chapterId=${chapters[0]._id}` : '#'}" 
+                           class="bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-5 rounded-lg shadow transition-colors text-center text-sm sm:text-base ${chapters.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}">
+                            <i class="fas fa-book-open mr-1 sm:mr-2"></i>Đọc từ đầu
+                        </a>
+                        <button id="follow-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-5 rounded-lg shadow transition-colors text-sm sm:text-base">
+                            <i class="fas fa-heart mr-1 sm:mr-2"></i>Theo dõi
+                        </button>
+                         <a href="${chapters.length > 0 ? `chapter-reader.html?comicId=${comic._id}&chapterId=${chapters[chapters.length - 1]._id}` : '#'}" 
+                           class="bg-sky-500 hover:bg-sky-600 text-white font-semibold py-2 px-5 rounded-lg shadow transition-colors text-center text-sm sm:text-base ${chapters.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}">
+                            <i class="fas fa-list-ol mr-1 sm:mr-2"></i>Đọc mới nhất
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-10">
+                <h2 class="text-xl sm:text-2xl font-bold mb-4 border-b-2 border-blue-500 pb-2">Danh Sách Chương</h2>
+                <div id="chapter-list-container" class="max-h-96 overflow-y-auto bg-gray-50 dark:bg-gray-700/50 rounded-md shadow p-2 space-y-1">
+                    </div>
+            </div>
+        `;
+
+        const chapterListContainer = document.getElementById('chapter-list-container');
+        if (chapters && chapters.length > 0) {
+            const chapterItemTemplate = await fetch('components/chapter-item.html').then(res => res.text());
+            // Sắp xếp chương theo chapterNumber giảm dần (mới nhất lên đầu) nếu backend chưa làm
+            // chapters.sort((a, b) => b.chapterNumber - a.chapterNumber); 
+            // Backend đã sort chapterNumber tăng dần, nên ta đảo ngược lại để hiển thị mới nhất lên đầu
+            chapters.reverse().forEach(chapter => { 
+                const chapterHtml = populateChapterItem(chapterItemTemplate, chapter, comic._id);
+                chapterListContainer.insertAdjacentHTML('beforeend', chapterHtml);
+            });
+        } else {
+            chapterListContainer.innerHTML = '<p class="p-4 text-gray-500 dark:text-gray-400 text-center">Chưa có chương nào cho truyện này.</p>';
+        }
+
+        const followButton = document.getElementById('follow-btn');
+        if (followButton) {
+            followButton.addEventListener('click', () => {
+                // Thay thế alert bằng modal hoặc thông báo tùy chỉnh
+                alert('Chức năng theo dõi sẽ được phát triển trong tương lai!');
+            });
+        }
+
+    } catch (error) {
+        console.error("Lỗi khởi tạo trang chi tiết truyện:", error);
+        comicDetailContent.innerHTML = `<p class="text-red-500 text-center p-10">Lỗi tải thông tin truyện: ${error.message}</p>`;
+    }
+}
+export { initComicDetailPage };
+console.log("comic-detail.js đã được tải và sẵn sàng tương tác với backend.");
+

--- a/docs/js/home.js
+++ b/docs/js/home.js
@@ -1,0 +1,102 @@
+// comic-frontend/js/home.js
+import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
+
+async function initHomePage() {
+    console.log("Đang khởi tạo Trang Chủ với dữ liệu từ Backend...");
+    const featuredList = document.getElementById('featured-comics-list');
+    const latestUpdatesList = document.getElementById('latest-updates-list');
+    const topDayList = document.getElementById('top-day-list');
+    const topWeekList = document.getElementById('top-week-list');
+    const topMonthList = document.getElementById('top-month-list');
+
+    if (!featuredList || !latestUpdatesList || !topDayList || !topWeekList || !topMonthList) {
+        console.error("Một hoặc nhiều phần tử cho trang chủ không được tìm thấy.");
+        return;
+    }
+
+    // Hiển thị trạng thái loading
+    featuredList.innerHTML = '<p class="text-gray-500 dark:text-gray-400 col-span-full text-center py-10">Đang tải truyện nổi bật...</p>';
+    latestUpdatesList.innerHTML = '<p class="text-gray-500 dark:text-gray-400 col-span-full text-center py-10">Đang tải truyện mới cập nhật...</p>';
+    topDayList.innerHTML = '<li>Đang tải...</li>';
+    topWeekList.innerHTML = '<li>Đang tải...</li>';
+    topMonthList.innerHTML = '<li>Đang tải...</li>';
+
+    try {
+        // Lấy template card truyện
+        const comicCardTemplate = await fetch('components/comic-card.html').then(res => res.text());
+
+        // Hàm render danh sách truyện
+        const renderComics = (element, comicsData, placeholderMessage) => {
+            element.innerHTML = ''; // Xóa loading
+            if (!comicsData || comicsData.length === 0) {
+                element.innerHTML = `<p class="text-gray-500 dark:text-gray-400 col-span-full text-center py-10">${placeholderMessage}</p>`;
+                return;
+            }
+            comicsData.forEach(comic => {
+                const cardHtml = populateComicCard(comicCardTemplate, comic);
+                element.insertAdjacentHTML('beforeend', cardHtml);
+            });
+        };
+        
+        // Hàm render bảng xếp hạng
+        const renderRankingList = (listElement, comicsData, placeholderMessage) => {
+            listElement.innerHTML = ''; // Xóa loading
+            if (!comicsData || comicsData.length === 0) {
+                listElement.innerHTML = `<li class="p-2 text-gray-500 dark:text-gray-400">${placeholderMessage}</li>`;
+                return;
+            }
+            comicsData.slice(0, 5).forEach((comic, index) => { // Chỉ hiển thị top 5
+                const listItem = `
+                    <li class="flex items-center justify-between p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+                        <a href="comic-detail.html?id=${comic._id}" class="truncate flex-grow text-sm hover:text-blue-500 dark:hover:text-blue-400">
+                            <span class="font-bold text-blue-600 dark:text-blue-500 mr-2">${index + 1}.</span> ${comic.title}
+                        </a>
+                        <span class="text-xs text-gray-500 dark:text-gray-400 ml-2 flex-shrink-0"><i class="fas fa-eye mr-1"></i>${comic.views ? comic.views.toLocaleString() : '0'}</span>
+                    </li>`;
+                listElement.insertAdjacentHTML('beforeend', listItem);
+            });
+        };
+
+        // Lấy truyện nổi bật (ví dụ: 6 truyện xem nhiều nhất)
+        const featuredResponse = await apiRequest('/stories?limit=6&sort=-views');
+        if (featuredResponse.success) {
+            renderComics(featuredList, featuredResponse.data, 'Không có truyện nổi bật.');
+        } else {
+            featuredList.innerHTML = `<p class="text-red-500 col-span-full text-center py-10">Lỗi tải truyện nổi bật: ${featuredResponse.error}</p>`;
+        }
+
+        // Lấy truyện mới cập nhật (ví dụ: 12 truyện mới nhất)
+        const latestResponse = await apiRequest('/stories?limit=12&sort=-updatedAt');
+        if (latestResponse.success) {
+            renderComics(latestUpdatesList, latestResponse.data, 'Chưa có truyện mới cập nhật.');
+        } else {
+            latestUpdatesList.innerHTML = `<p class="text-red-500 col-span-full text-center py-10">Lỗi tải truyện mới cập nhật: ${latestResponse.error}</p>`;
+        }
+        
+        // Lấy bảng xếp hạng (ví dụ: Top Ngày, Tuần, Tháng đều lấy theo views giảm dần cho đơn giản)
+        // Trong thực tế, bạn cần API riêng hoặc logic phức tạp hơn cho Top Tuần/Tháng
+        const topDayResponse = await apiRequest('/stories?sort=-views&limit=5'); // Giả sử top ngày là top views
+        if (topDayResponse.success) {
+            renderRankingList(topDayList, topDayResponse.data, 'Chưa có BXH Ngày.');
+            renderRankingList(topWeekList, topDayResponse.data, 'Chưa có BXH Tuần.'); // Cần API riêng
+            renderRankingList(topMonthList, topDayResponse.data, 'Chưa có BXH Tháng.'); // Cần API riêng
+        } else {
+            const errorMsg = `<li class="p-2 text-red-500">Lỗi tải BXH: ${topDayResponse.error}</li>`;
+            topDayList.innerHTML = errorMsg;
+            topWeekList.innerHTML = errorMsg;
+            topMonthList.innerHTML = errorMsg;
+        }
+
+    } catch (error) {
+        console.error("Lỗi khởi tạo trang chủ:", error);
+        const errorMsg = `<p class="text-red-500 col-span-full text-center py-10">Đã xảy ra lỗi khi tải dữ liệu: ${error.message}</p>`;
+        if (featuredList) featuredList.innerHTML = errorMsg;
+        if (latestUpdatesList) latestUpdatesList.innerHTML = errorMsg;
+        // (Thêm cho ranking lists nếu muốn)
+    }
+}
+
+export { initHomePage };
+
+console.log("home.js đã được tải và sẵn sàng tương tác với backend.");

--- a/docs/js/init-search.js
+++ b/docs/js/init-search.js
@@ -1,0 +1,10 @@
+// js/init-search.js
+import { loadComponent } from './main.js';
+import { initSearchPage } from './search.js';
+
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadComponent('components/navbar.html', 'navbar-placeholder');
+  await loadComponent('components/footer.html', 'footer-placeholder');
+  initSearchPage(); // Gọi đúng entry point của search page
+});
+

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -1,0 +1,10 @@
+import { loadComponent } from './main.js';
+import { initHomePage } from './home.js';
+
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadComponent('components/navbar.html', 'navbar-placeholder');
+  await loadComponent('components/footer.html', 'footer-placeholder'); 
+    initHomePage();
+  
+});
+

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,126 @@
+// comic-frontend/js/main.js
+
+// Hàm để tải các component HTML (navbar, footer)
+async function loadComponent(componentPath, targetElementId, callback) {
+  try {
+    const response = await fetch(componentPath);
+    if (!response.ok) throw new Error(`Lỗi HTTP! Trạng thái: ${response.status}, đường dẫn: ${componentPath}`);
+    const html = await response.text();
+    const targetElement = document.getElementById(targetElementId);
+    if (targetElement) {
+        targetElement.innerHTML = html;
+        // Thực thi script bên trong component nếu có (ví dụ: script trong navbar.html)
+        const scripts = targetElement.getElementsByTagName('script');
+        for (let i = 0; i < scripts.length; i++) {
+            // Tạo một script element mới để trình duyệt thực thi nó
+            const newScript = document.createElement('script');
+            if (scripts[i].src) {
+                newScript.src = scripts[i].src;
+            } else {
+                newScript.textContent = scripts[i].textContent;
+            }
+            // Thêm type="module" nếu script gốc có
+            if (scripts[i].type === 'module') {
+                newScript.type = 'module';
+            }
+            document.head.appendChild(newScript).parentNode.removeChild(newScript); // Một cách để thực thi script
+        }
+
+        if (callback && typeof callback === 'function') {
+            callback(); // Gọi callback sau khi component được tải và script (nếu có) đã được thêm
+        }
+    } else {
+        console.warn(`Không tìm thấy phần tử đích với ID '${targetElementId}' cho component '${componentPath}'.`);
+    }
+  } catch (error) {
+    console.error(`Không thể tải component: ${componentPath}`, error);
+    const targetElement = document.getElementById(targetElementId);
+    if(targetElement) targetElement.innerHTML = `<p class="text-red-500">Lỗi tải ${componentPath.split('/').pop()}.</p>`;
+  }
+}
+
+// Chuyển đổi Chế độ Tối/Sáng
+function toggleDarkMode() {
+    const htmlElement = document.documentElement;
+    htmlElement.classList.toggle('dark');
+    const isDarkMode = htmlElement.classList.contains('dark');
+    localStorage.setItem('darkMode', isDarkMode);
+
+    // Cập nhật icon cho tất cả các nút chuyển chế độ tối
+    const darkModeToggleButtons = document.querySelectorAll('.dark-mode-toggle-button');
+    darkModeToggleButtons.forEach(button => {
+        const icon = button.querySelector('i');
+        if (icon) {
+            if (isDarkMode) {
+                icon.classList.remove('fa-moon');
+                icon.classList.add('fa-sun');
+            } else {
+                icon.classList.remove('fa-sun');
+                icon.classList.add('fa-moon');
+            }
+        }
+    });
+}
+
+// Áp dụng chế độ tối đã lưu khi tải trang và thiết lập listener
+function applyInitialDarkMode() {
+    const htmlElement = document.documentElement;
+    const savedDarkMode = localStorage.getItem('darkMode');
+    if (savedDarkMode === 'true') {
+        htmlElement.classList.add('dark');
+    } else {
+        htmlElement.classList.remove('dark');
+    }
+
+    const darkModeToggleButtons = document.querySelectorAll('.dark-mode-toggle-button');
+     darkModeToggleButtons.forEach(button => {
+        const icon = button.querySelector('i');
+        if (icon) {
+            if (htmlElement.classList.contains('dark')) {
+                icon.classList.remove('fa-moon');
+                icon.classList.add('fa-sun');
+            } else {
+                icon.classList.remove('fa-sun');
+                icon.classList.add('fa-moon');
+            }
+        }
+        // Đảm bảo chỉ có một listener được gắn
+        button.removeEventListener('click', toggleDarkMode);
+        button.addEventListener('click', toggleDarkMode);
+    });
+}
+
+// Hàm tiện ích để điền dữ liệu vào template comic card
+function populateComicCard(template, comic) {
+    let populatedCard = template;
+    // Sử dụng _id từ MongoDB
+    populatedCard = populatedCard.replace(/{{comic_url}}/g, `comic-detail.html?id=${comic._id}`);
+    populatedCard = populatedCard.replace(/{{image_url}}/g, comic.coverImage || 'assets/images/cover-placeholder.jpg');
+    populatedCard = populatedCard.replace(/{{title}}/g, comic.title || 'Chưa có tiêu đề');
+    const latestChapterName = comic.latest_chapter_info ? comic.latest_chapter_info.title : (comic.latest_chapter || 'Đang cập nhật'); // Giả sử backend có thể trả về latest_chapter_info
+    populatedCard = populatedCard.replace(/{{latest_chapter_name}}/g, latestChapterName);
+    populatedCard = populatedCard.replace(/{{views}}/g, comic.views ? comic.views.toLocaleString() : '0');
+    return populatedCard;
+}
+
+// Hàm tiện ích để điền dữ liệu vào template chapter item
+function populateChapterItem(template, chapter, comicId) {
+    let populatedItem = template;
+    // Sử dụng _id từ MongoDB cho chapter và comicId
+    populatedItem = populatedItem.replace(/{{chapter_url}}/g, `chapter-reader.html?comicId=${comicId}&chapterId=${chapter._id}`);
+    populatedItem = populatedItem.replace(/{{chapter_name}}/g, chapter.title || `Chương ${chapter.chapterNumber}`);
+    const uploadDate = chapter.updatedAt ? new Date(chapter.updatedAt).toLocaleDateString('vi-VN') : 'N/A';
+    populatedItem = populatedItem.replace(/{{upload_date}}/g, uploadDate);
+    return populatedItem;
+}
+
+
+// Gọi applyInitialDarkMode khi DOM sẵn sàng
+document.addEventListener('DOMContentLoaded', () => {
+    applyInitialDarkMode();
+    // Các khởi tạo toàn cục khác có thể đặt ở đây
+});
+
+export { loadComponent, toggleDarkMode, populateComicCard, populateChapterItem };
+
+console.log("main.js đã được tải và các hàm đã được định nghĩa.");

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -1,0 +1,209 @@
+// comic-frontend/js/search.js
+import { apiRequest } from './api.js';
+import { populateComicCard } from './main.js';
+async function initSearchPage() {
+    console.log("Đang khởi tạo Trang Tìm Kiếm với dữ liệu từ Backend...");
+    const searchForm = document.getElementById('advanced-search-form');
+    const searchResultsList = document.getElementById('search-results-list');
+    const searchCategorySelect = document.getElementById('search-category');
+    const paginationContainer = document.getElementById('search-pagination'); // Thêm ID này vào search.html
+
+    if (!searchForm || !searchResultsList || !searchCategorySelect || !paginationContainer) {
+        console.error("Một hoặc nhiều phần tử cho trang tìm kiếm không được tìm thấy.");
+        if(searchResultsList) searchResultsList.innerHTML = '<p class="col-span-full text-center py-10 text-red-500">Lỗi giao diện trang tìm kiếm.</p>';
+        return;
+    }
+
+    // Tải danh sách thể loại cho dropdown
+    try {
+        const categoriesResponse = await apiRequest('/stories/categories'); // Giả sử có endpoint này ở backend
+                                                                        // Hoặc lấy từ một nguồn cố định nếu không có API
+        if (categoriesResponse && categoriesResponse.success && categoriesResponse.data) {
+            searchCategorySelect.innerHTML = '<option value="">Tất cả thể loại</option>'; // Giữ lại option mặc định
+            categoriesResponse.data.forEach(category => {
+                // Giả sử category là một string hoặc có trường name
+                const categoryName = typeof category === 'string' ? category : category.name;
+                const option = document.createElement('option');
+                option.value = categoryName.toLowerCase(); // Hoặc ID nếu backend dùng ID
+                option.textContent = categoryName;
+                searchCategorySelect.appendChild(option);
+            });
+        } else {
+             console.warn("Không thể tải danh sách thể loại cho tìm kiếm:", categoriesResponse ? categoriesResponse.error : "Lỗi không xác định");
+             // Sử dụng danh sách thể loại mặc định nếu API lỗi
+            const defaultCategories = ["Action", "Comedy", "Romance", "Fantasy", "Manhua", "Adventure"];
+            searchCategorySelect.innerHTML = '<option value="">Tất cả thể loại</option>';
+            defaultCategories.forEach(catName => {
+                const option = document.createElement('option');
+                option.value = catName.toLowerCase();
+                option.textContent = catName;
+                searchCategorySelect.appendChild(option);
+            });
+        }
+    } catch (error) {
+        console.error("Lỗi tải thể loại cho tìm kiếm:", error);
+    }
+
+
+    let currentSearchPage = 1;
+    let currentSearchParams = new URLSearchParams();
+
+
+    async function performSearch(page = 1) {
+        currentSearchPage = page;
+        searchResultsList.innerHTML = '<p class="col-span-full text-center text-gray-500 dark:text-gray-400 py-10">Đang tìm kiếm...</p>';
+        paginationContainer.innerHTML = ''; // Xóa phân trang cũ
+
+        const formData = new FormData(searchForm);
+        const params = new URLSearchParams();
+        for (const pair of formData) {
+            if (pair[1]) { // Chỉ thêm vào params nếu có giá trị
+               params.append(pair[0], pair[1]);
+            }
+        }
+        params.set('page', currentSearchPage);
+        params.set('limit', 18); // 18 truyện mỗi trang
+        currentSearchParams = params; // Lưu lại params hiện tại cho phân trang
+
+        // Cập nhật URL trình duyệt
+        history.pushState(null, '', `${window.location.pathname}?${params.toString()}`);
+
+
+        try {
+            const response = await apiRequest(`/stories?${params.toString()}`);
+
+            if (response.success && response.data) {
+                const comics = response.data;
+                const comicCardTemplate = await fetch('components/comic-card.html').then(res => res.text());
+
+                searchResultsList.innerHTML = ''; // Xóa loading
+                if (comics.length === 0) {
+                    searchResultsList.innerHTML = '<p class="col-span-full text-center text-gray-500 dark:text-gray-400 py-10">Không tìm thấy truyện nào phù hợp với tiêu chí của bạn.</p>';
+                } else {
+                    comics.forEach(comic => {
+                        const cardHtml = populateComicCard(comicCardTemplate, comic);
+                        searchResultsList.insertAdjacentHTML('beforeend', cardHtml);
+                    });
+                }
+                renderSearchPagination(response.pagination, response.total, response.count);
+            } else {
+                throw new Error(response.error || 'Không thể thực hiện tìm kiếm.');
+            }
+        } catch (error) {
+            console.error("Lỗi tìm kiếm:", error);
+            searchResultsList.innerHTML = `<p class="col-span-full text-center text-red-500 py-10">Lỗi khi tìm kiếm: ${error.message}</p>`;
+        }
+    }
+    
+    function renderSearchPagination(paginationData, totalItems, itemsOnPage) {
+        // Hàm renderPagination tương tự như trong category.js
+        // Bạn có thể tách hàm này ra js/utils.js để tái sử dụng
+        if (!paginationData && totalItems <= itemsOnPage) {
+            paginationContainer.innerHTML = '';
+            return;
+        }
+
+        let paginationHTML = '<ul class="inline-flex items-center -space-x-px">';
+        const limit = 18;
+        const totalPages = Math.ceil(totalItems / limit);
+
+        // Nút Previous
+        if (paginationData && paginationData.prev) {
+            paginationHTML += `<li><a href="#" data-page="${paginationData.prev.page}" class="search-pagination-link py-2 px-3 ml-0 leading-tight text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">Trước</a></li>`;
+        } else {
+            paginationHTML += `<li><span class="py-2 px-3 ml-0 leading-tight text-gray-400 bg-white rounded-l-lg border border-gray-300 cursor-not-allowed dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500">Trước</span></li>`;
+        }
+
+        const maxPagesToShow = 5;
+        let startPage = Math.max(1, currentSearchPage - Math.floor(maxPagesToShow / 2));
+        let endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+         if (totalPages > maxPagesToShow && endPage - startPage + 1 < maxPagesToShow) {
+             startPage = Math.max(1, endPage - maxPagesToShow + 1);
+        }
+
+        if (startPage > 1) {
+            paginationHTML += `<li><a href="#" data-page="1" class="search-pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">1</a></li>`;
+            if (startPage > 2) {
+                paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">...</span></li>`;
+            }
+        }
+        for (let i = startPage; i <= endPage; i++) {
+            if (i === currentSearchPage) {
+                paginationHTML += `<li><span aria-current="page" class="z-10 py-2 px-3 leading-tight text-blue-600 bg-blue-50 border border-blue-300 dark:border-gray-700 dark:bg-gray-700 dark:text-white">${i}</span></li>`;
+            } else {
+                paginationHTML += `<li><a href="#" data-page="${i}" class="search-pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">${i}</a></li>`;
+            }
+        }
+        if (endPage < totalPages) {
+             if (endPage < totalPages - 1) {
+                paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400">...</span></li>`;
+            }
+            paginationHTML += `<li><a href="#" data-page="${totalPages}" class="search-pagination-link py-2 px-3 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">${totalPages}</a></li>`;
+        }
+
+        // Nút Next
+        if (paginationData && paginationData.next) {
+            paginationHTML += `<li><a href="#" data-page="${paginationData.next.page}" class="search-pagination-link py-2 px-3 leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white">Sau</a></li>`;
+        } else {
+            paginationHTML += `<li><span class="py-2 px-3 leading-tight text-gray-400 bg-white rounded-r-lg border border-gray-300 cursor-not-allowed dark:bg-gray-800 dark:border-gray-700 dark:text-gray-500">Sau</span></li>`;
+        }
+        paginationHTML += '</ul>';
+        paginationContainer.innerHTML = paginationHTML;
+
+        document.querySelectorAll('.search-pagination-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const page = parseInt(e.target.closest('a').dataset.page);
+                performSearch(page);
+            });
+        });
+    }
+
+
+    searchForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        performSearch(1); // Khi submit form, tìm từ trang 1
+    });
+
+    // Kiểm tra nếu có query params trên URL khi tải trang (ví dụ từ bookmark hoặc link trực tiếp)
+    const initialUrlParams = new URLSearchParams(window.location.search);
+    if (initialUrlParams.has('name') || initialUrlParams.has('category') || initialUrlParams.has('author') || initialUrlParams.has('status')) {
+        // Điền form từ URL params
+        document.getElementById('search-name').value = initialUrlParams.get('name') || '';
+        document.getElementById('search-author').value = initialUrlParams.get('author') || '';
+        document.getElementById('search-category').value = initialUrlParams.get('category') || '';
+        document.getElementById('search-status').value = initialUrlParams.get('status') || '';
+        document.getElementById('search-sort').value = initialUrlParams.get('sort') || 'relevance'; // Giả sử 'relevance' là giá trị mặc định
+        currentSearchPage = parseInt(initialUrlParams.get('page')) || 1;
+        performSearch(currentSearchPage);
+    }
+     // Xử lý khi người dùng nhấn nút back/forward của trình duyệt
+    window.addEventListener('popstate', () => {
+        const newParams = new URLSearchParams(window.location.search);
+        // Điền lại form từ newParams và thực hiện tìm kiếm
+        document.getElementById('search-name').value = newParams.get('name') || '';
+        document.getElementById('search-author').value = newParams.get('author') || '';
+        document.getElementById('search-category').value = newParams.get('category') || '';
+        document.getElementById('search-status').value = newParams.get('status') || '';
+        document.getElementById('search-sort').value = newParams.get('sort') || 'relevance';
+        const newPage = parseInt(newParams.get('page')) || 1;
+        performSearch(newPage);
+    });
+}
+export { initSearchPage };
+
+console.log("search.js đã được tải và sẵn sàng tương tác với backend.");
+
+// Endpoint lấy danh sách thể loại ở backend (ví dụ)
+// Trong comic-backend/routes/storyRoutes.js, thêm:
+/*
+router.get('/categories', async (req, res) => {
+    try {
+        const categories = await Story.distinct('genres');
+        res.status(200).json({ success: true, data: categories.sort() });
+    } catch (error) {
+        res.status(500).json({ success: false, error: 'Không thể lấy danh sách thể loại' });
+    }
+});
+*/
+// Bạn cần thêm route này vào backend và đảm bảo nó hoạt động.


### PR DESCRIPTION
## Summary
- copy module-based JS from `comic-frontend/js/` into `docs/js`
- load `init.js` as a module on the docs home page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbfe0c6688324a5e774a1c405b664